### PR TITLE
update a comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,7 @@ pub fn reduce_colors<T: GenericImage> (image: T, colors: &[Rgb<u8>]) -> RgbImage
                 let g = c.0[1] as i32 - color.0[1] as i32;
                 // Calculate the difference between the blue of the given color and pixel color.
                 let b = c.0[2] as i32 - color.0[2] as i32;
-                // Do something magical to combine all four differences into one similarity value.
-                // I don't really know how this works, but if someone does, please feel free to fork
-                // and change this comment.
+                // Calculate the distance between the colors in RGB space.
                 let s = r.pow(2) + g.pow(2) + b.pow(2);
 
                 // If the given color is more similar than the current most similar color, then


### PR DESCRIPTION
here's my attempt at explaining the line you couldn't figure out.

if the RGB spectrum was presented as a three-dimensional space, then the sum of the squares of the differences calculates the "distance" between the two colors in RGB space. colors that are closer are thus more similar to each other.

i've tried to update the comment accordingly. i've also turned PR edits on, so feel free to revise the comment however you see fit before merging.

if you ever update the lib, using a colorspace more similar to human perception (such as HSL or [CIELAB](https://commons.wikimedia.org/wiki/File:Srgb-in-cielab.png)) would improve the accuracy of the similarity algorithm.